### PR TITLE
シリアルキラー(misimo)追加

### DIFF
--- a/TheOtherRoles/CustomOptionHolder.cs
+++ b/TheOtherRoles/CustomOptionHolder.cs
@@ -282,6 +282,9 @@ namespace TheOtherRoles {
         public static CustomOption plagueDoctorInfectKiller;
         public static CustomOption plagueDoctorResetMeeting;
         public static CustomOption plagueDoctorWinDead;
+        public static CustomRoleOption serialKillerSpawnRate;
+        public static CustomOption serialKillerKillCooldown;
+        public static CustomOption serialKillerSuicideTimer;
 
         internal static Dictionary<byte, byte[]> blockedRolePairings = new Dictionary<byte, byte[]>();
         internal static List<byte> blockLovers = new List<byte>();
@@ -378,6 +381,9 @@ namespace TheOtherRoles {
             ninjaCanBeTargeted = CustomOption.Create(1007, "ninjaCanBeTargeted", true, ninjaSpawnRate);
             ninjaCanVent = CustomOption.Create(1008, "ninjaCanVent", false, ninjaSpawnRate);
 
+            serialKillerSpawnRate = new CustomRoleOption(1010, "serialKiller", SerialKiller.color, 1);
+            serialKillerKillCooldown = CustomOption.Create(1012, "serialKillerKillCooldown", 15f, 1f, 60f, 0.5f, serialKillerSpawnRate, format: "unitSeconds");
+            serialKillerSuicideTimer = CustomOption.Create(1013, "serialKillerSuicideTimer", 40f, 1f, 60f, 0.5f, serialKillerSpawnRate, format: "unitSeconds");
 
             madmateSpawnRate = new CustomRoleOption(360, "madmate", Madmate.color);
             madmateCanDieToSheriff = CustomOption.Create(361, "madmateCanDieToSheriff", false, madmateSpawnRate);

--- a/TheOtherRoles/Patches/RoleAssignmentPatch.cs
+++ b/TheOtherRoles/Patches/RoleAssignmentPatch.cs
@@ -130,6 +130,7 @@ namespace TheOtherRoles.Patches
             impSettings.Add((byte)RoleId.BountyHunter, CustomOptionHolder.bountyHunterSpawnRate.data);
             impSettings.Add((byte)RoleId.Witch, CustomOptionHolder.witchSpawnRate.data);
             impSettings.Add((byte)RoleId.Ninja, CustomOptionHolder.ninjaSpawnRate.data);
+            impSettings.Add((byte)RoleId.SerialKiller, CustomOptionHolder.serialKillerSpawnRate.data);
 
             neutralSettings.Add((byte)RoleId.Jester, CustomOptionHolder.jesterSpawnRate.data);
             neutralSettings.Add((byte)RoleId.Arsonist, CustomOptionHolder.arsonistSpawnRate.data);

--- a/TheOtherRoles/RPC.cs
+++ b/TheOtherRoles/RPC.cs
@@ -50,6 +50,7 @@ namespace TheOtherRoles
         Witch,
         Ninja,
         Madmate,
+        SerialKiller,
 
 
         Mini = 150,
@@ -140,6 +141,7 @@ namespace TheOtherRoles
         PlagueDoctorWin,
         PlagueDoctorSetInfected,
         PlagueDoctorUpdateProgress,
+        SerialKillerSuicide,
     }
 
     public static class RPCProcedure {
@@ -561,6 +563,10 @@ namespace TheOtherRoles
 
                     case RoleId.PlagueDoctor:
                         PlagueDoctor.swapRole(player, oldShifter);
+                        break;
+
+                    case RoleId.SerialKiller:
+                        SerialKiller.swapRole(player, oldShifter);
                         break;
                 }
             }
@@ -1011,6 +1017,11 @@ namespace TheOtherRoles
         public static void plagueDoctorProgress(byte targetId, float progress) {
 			PlagueDoctor.progress[targetId] = progress;
         }
+        public static void serialKillerSuicide(byte serialKillerId ) {
+            PlayerControl serialKiller = Helpers.playerById(serialKillerId);
+            if (serialKiller == null) return;
+            serialKiller.MurderPlayer(serialKiller);
+        }
     }   
 
     
@@ -1240,6 +1251,10 @@ namespace TheOtherRoles
 					byte[] progressByte =  reader.ReadBytes(4);
 					float progress = System.BitConverter.ToSingle(progressByte, 0);
                     RPCProcedure.plagueDoctorProgress(progressTarget, progress);
+                    break;
+
+                case (byte)CustomRPC.SerialKillerSuicide:
+                    RPCProcedure.serialKillerSuicide(reader.ReadByte());
                     break;
             }
         }

--- a/TheOtherRoles/RoleInfo.cs
+++ b/TheOtherRoles/RoleInfo.cs
@@ -86,6 +86,7 @@ namespace TheOtherRoles
         public static RoleInfo medium = new RoleInfo("medium", Medium.color, CustomOptionHolder.mediumSpawnRate, RoleId.Medium);
         public static RoleInfo ninja = new RoleInfo("ninja", Ninja.color, CustomOptionHolder.ninjaSpawnRate, RoleId.Ninja);
         public static RoleInfo plagueDoctor = new RoleInfo("plagueDoctor", PlagueDoctor.color, CustomOptionHolder.plagueDoctorSpawnRate, RoleId.PlagueDoctor);
+        public static RoleInfo serialKiller = new RoleInfo("serialKiller", SerialKiller.color, CustomOptionHolder.serialKillerSpawnRate, RoleId.SerialKiller);
 
         public static List<RoleInfo> allRoleInfos = new List<RoleInfo>() {
                 impostor,
@@ -102,6 +103,7 @@ namespace TheOtherRoles
                 bountyHunter,
                 witch,
                 ninja,
+                serialKiller,
                 niceMini,
                 evilMini,
                 niceGuesser,
@@ -194,6 +196,7 @@ namespace TheOtherRoles
             if (p.isRole(RoleId.Pursuer)) infos.Add(pursuer);
             if (p.isRole(RoleId.Ninja)) infos.Add(ninja);
             if (p.isRole(RoleId.PlagueDoctor)) infos.Add(plagueDoctor);
+            if (p.isRole(RoleId.SerialKiller)) infos.Add(serialKiller);
 
 
             // Default roles

--- a/TheOtherRoles/Roles/ButtonsGM.cs
+++ b/TheOtherRoles/Roles/ButtonsGM.cs
@@ -27,6 +27,7 @@ namespace TheOtherRoles
             Sheriff.SetButtonCooldowns();
             PlagueDoctor.SetButtonCooldowns();
             Lighter.SetButtonCooldowns();
+            SerialKiller.SetButtonCooldowns();
 
             foreach (CustomButton gmButton in gmButtons)
             {
@@ -47,6 +48,7 @@ namespace TheOtherRoles
             Sheriff.MakeButtons(hm);
             PlagueDoctor.MakeButtons(hm);
             Lighter.MakeButtons(hm);
+            SerialKiller.MakeButtons(hm);
 
             gmButtons = new List<CustomButton>();
             gmKillButtons = new List<CustomButton>();

--- a/TheOtherRoles/Roles/CustomRolesGM.cs
+++ b/TheOtherRoles/Roles/CustomRolesGM.cs
@@ -35,6 +35,7 @@ namespace TheOtherRoles
             Madmate.Clear();
             PlagueDoctor.Clear();
             Lighter.Clear();
+            SerialKiller.Clear();
             Role.ClearAll();
         }
 

--- a/TheOtherRoles/Roles/Role.cs
+++ b/TheOtherRoles/Roles/Role.cs
@@ -27,6 +27,7 @@ namespace TheOtherRoles
             { typeof(RoleBase<Sheriff>), RoleId.Sheriff },
             { typeof(RoleBase<Lighter>), RoleId.Lighter },
             { typeof(RoleBase<Ninja>), RoleId.Ninja },
+            { typeof(RoleBase<SerialKiller>), RoleId.SerialKiller },
             { typeof(RoleBase<Madmate>), RoleId.Madmate },
             { typeof(RoleBase<Opportunist>), RoleId.Opportunist },
             { typeof(RoleBase<PlagueDoctor>), RoleId.PlagueDoctor },

--- a/TheOtherRoles/Roles/SerialKiller.cs
+++ b/TheOtherRoles/Roles/SerialKiller.cs
@@ -1,0 +1,110 @@
+
+using System.Linq;
+using HarmonyLib;
+using Hazel;
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using TheOtherRoles.Objects;
+using TheOtherRoles.Patches;
+
+namespace TheOtherRoles
+{
+    [HarmonyPatch]
+    public class SerialKiller : RoleBase<SerialKiller> {
+
+        private static CustomButton serialKillerButton;
+
+        public static Color color = Palette.ImpostorRed;
+
+        public static float killCooldown { get { return CustomOptionHolder.serialKillerKillCooldown.getFloat(); } }
+        public static float suicideTimer { get { return CustomOptionHolder.serialKillerSuicideTimer.getFloat(); } }
+        public static bool isCountDown = false;
+
+
+        public SerialKiller()
+        {
+        }
+
+        public override void OnMeetingStart()
+        {
+            if (player == PlayerControl.LocalPlayer)
+            {
+            }
+        }
+
+        public override void OnMeetingEnd() { }
+
+        public override void FixedUpdate() { }
+        public override void HandleDisconnect(PlayerControl player, DisconnectReasons reason) { }
+
+
+        public override void OnKill(PlayerControl target)
+        {
+            player.SetKillTimerUnchecked(killCooldown);
+            serialKillerButton.Timer = suicideTimer;
+            isCountDown = true;
+        }
+
+        public override void OnDeath(PlayerControl killer) { }
+
+        private static Sprite buttonSprite;
+        public static Sprite getButtonSprite()
+        {
+            if (buttonSprite) return buttonSprite;
+            buttonSprite = Helpers.loadSpriteFromResources("TheOtherRoles.Resources.CurseKillButton.png", 115f);
+            return buttonSprite;
+        }
+
+        public static void MakeButtons(HudManager hm)
+        {
+            // SerialKiller Suicide CountDown
+            serialKillerButton = new CustomButton(
+                () => {},
+                () => {return PlayerControl.LocalPlayer.isRole(RoleId.SerialKiller) && !PlayerControl.LocalPlayer.Data.IsDead && isCountDown;},
+                () => {return false;},
+                () => {serialKillerButton.Timer = suicideTimer;},
+                SerialKiller.getButtonSprite(),
+                new Vector3(-1.8f, -0.06f, 0),
+                hm,
+                hm.AbilityButton,
+                KeyCode.F,
+                true,
+                1f,
+                () => {SerialKiller.suicide();}
+            );
+            serialKillerButton.buttonText = ModTranslation.getString("SerialKillerText");
+            serialKillerButton.isEffectActive = true;
+        }
+
+        public static void suicide(){
+                byte targetId = PlayerControl.LocalPlayer.PlayerId;
+                MessageWriter killWriter = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.SerialKillerSuicide, Hazel.SendOption.Reliable, -1); killWriter.Write(targetId);
+                AmongUsClient.Instance.FinishRpcImmediately(killWriter);
+                RPCProcedure.serialKillerSuicide(targetId);
+        }
+
+        public static void SetButtonCooldowns()
+        {
+            serialKillerButton.MaxTimer = SerialKiller.suicideTimer;
+        }
+
+        public static void Clear()
+        {
+            players = new List<SerialKiller>();
+            isCountDown = false;
+        }
+
+        [HarmonyPatch(typeof(ExileController), nameof(ExileController.ReEnableGameplay))]
+        class ExileControllerReEnableGameplayPatch {
+            public static void Postfix(ExileController __instance) {
+                PlayerControl player = PlayerControl.LocalPlayer;
+                if(player.isRole(RoleId.SerialKiller))
+                {
+                    player.SetKillTimerUnchecked(killCooldown);
+                    serialKillerButton.Timer = suicideTimer;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
追加役職の第二弾です。
キルクールダウンが短い代わりにキルをし続けないと死んでしまうインポスター役職です

インポスター陣営
- 役職固有のキルクールダウンを設定可能（通常のインポスターの半分程度を推奨）
- 一度キルを行うと一定時間経過後に自殺する
- キルを行うと自殺までの時間経過がリセットされる

※前回同様エクセルがないのでテキスト対応できていません。
※ボタン画像はwarlockの画像を使いまわしているので適当に差し替えてください