### PR TITLE
感染状況テキスト表示のnull参照修正

### DIFF
--- a/TheOtherRoles/Roles/PlagueDoctor.cs
+++ b/TheOtherRoles/Roles/PlagueDoctor.cs
@@ -180,7 +180,10 @@ namespace TheOtherRoles
         {
             if (MeetingHud.Instance != null)
             {
-                statusText.gameObject.SetActive(false);
+                if (statusText != null)
+                {
+                    statusText.gameObject.SetActive(false);
+                }
                 return;
             }
 


### PR DESCRIPTION
会議時にクルーメイトの場合にnull参照が起きているので修正必要です