### PR TITLE
Windowsでビルドした際にstringData.jsonの改行コードがCRLFになってしまう

### DIFF
--- a/stringsToJson.py
+++ b/stringsToJson.py
@@ -37,7 +37,7 @@ def stringToJson(filename):
       if data:
         stringData[name] = data
     
-  with open(OUT_FILE, "w") as f:
+  with open(OUT_FILE, "w", newline="\n") as f:
     json.dump(stringData, f, indent=4)
 
 if __name__ == "__main__":


### PR DESCRIPTION
Windows環境でビルドするとその都度改行コードが変更されて差分が出てしまいます。
コミット対象から毎回外すのが煩わしいので明示的に改行コードをLFに指定していただけると助かります。