### PR TITLE
エアシップで会議終了後にシリアルキラーのキルクールダウンが正常にセットされない

### DIFF
--- a/TheOtherRoles/Roles/SerialKiller.cs
+++ b/TheOtherRoles/Roles/SerialKiller.cs
@@ -42,7 +42,17 @@ namespace TheOtherRoles
             }
         }
 
-        public override void FixedUpdate() { }
+        public override void FixedUpdate()
+        {
+            // エアシップで会議後のクールダウンが正常にセットされない暫定対応
+            if(player == PlayerControl.LocalPlayer)
+            {
+                if(player.killTimer > killCooldown)
+                {
+                    player.SetKillTimerUnchecked(killCooldown);
+                }
+            }
+        }
         public override void HandleDisconnect(PlayerControl player, DisconnectReasons reason) { }
 
         public override void OnKill(PlayerControl target)


### PR DESCRIPTION
※適切な対応が見つからず、暫定対応です 

エアシップのみで発生

呼び出し元不明の呼び出しでクールダウン設定が上書きされてしまう

[Info   :The Other Roles GM] SetKillTimerUnchecked time=5 max=5　★シリアルキラーのクールダウン設定
[Info   :The Other Roles GM] SetKillTimerUnchecked time=60 max=60　★通常のキルクールダウン設定
```
[Info   :The Other Roles GM] SetKillTimerUnchecked time=5 max=5
[Info   :The Other Roles GM]   at System.Environment.get_StackTrace () [0x00000] in <986ed57b9a8f4699a3c59a69eb05944a>:0 
  at TheOtherRoles.Patches.PlayerControlSetCoolDownPatch.SetKillTimerUnchecked (PlayerControl player, System.Single time, System.Single max) [0x00000] in <09e15cd29e85405f9bb0b41a1fb96420>:0 
  at TheOtherRoles.SerialKiller.OnMeetingEnd () [0x00000] in <09e15cd29e85405f9bb0b41a1fb96420>:0 
  at TheOtherRoles.TheOtherRolesGM.OnMeetingEnd () [0x00000] in <09e15cd29e85405f9bb0b41a1fb96420>:0 
  at TheOtherRoles.Patches.ExileControllerWrapUpPatch.WrapUpPostfix (GameData+PlayerInfo exiled) [0x00000] in <09e15cd29e85405f9bb0b41a1fb96420>:0 
  at TheOtherRoles.Patches.ExileControllerWrapUpPatch+AirshipExileControllerPatch.Postfix (AirshipExileController __instance) [0x00000] in <09e15cd29e85405f9bb0b41a1fb96420>:0 
  at AirshipExileController.DMD<AirshipExileController::WrapUpAndSpawn> (AirshipExileController ) [0x00000] in <d3e32ffbd92e4759b746c9e9561214e6>:0 
  at MonoMod.Utils.DynamicMethodDefinition.(il2cpp -> managed) WrapUpAndSpawn (System.IntPtr , UnhollowerBaseLib.Runtime.Il2CppMethodInfo* ) [0x00000] in <af9435f826334c758c950dc531a96591>:0 
[Info   :The Other Roles GM] SetKillTimerUnchecked time=60 max=60
[Info   :The Other Roles GM]   at System.Environment.get_StackTrace () [0x00000] in <986ed57b9a8f4699a3c59a69eb05944a>:0 
  at TheOtherRoles.Patches.PlayerControlSetCoolDownPatch.SetKillTimerUnchecked (PlayerControl player, System.Single time, System.Single max) [0x00000] in <09e15cd29e85405f9bb0b41a1fb96420>:0 
  at TheOtherRoles.Patches.PlayerControlSetCoolDownPatch.Prefix (PlayerControl __instance, System.Single time) [0x00000] in <09e15cd29e85405f9bb0b41a1fb96420>:0 
  at PlayerControl.DMD<PlayerControl::SetKillTimer> (PlayerControl , System.Single ) [0x00000] in <d3e32ffbd92e4759b746c9e9561214e6>:0 
  at MonoMod.Utils.DynamicMethodDefinition.(il2cpp -> managed) SetKillTimer (System.IntPtr , System.Single , UnhollowerBaseLib.Runtime.Il2CppMethodInfo* ) [0x00000] in <af9435f826334c758c950dc531a96591>:0
```