### PR TITLE
背徳者→妖狐の矢印が表示されないことがある不具合の修正

### DIFF
--- a/TheOtherRoles/Roles/Immoralist.cs
+++ b/TheOtherRoles/Roles/Immoralist.cs
@@ -43,6 +43,11 @@ namespace TheOtherRoles
 
         public static void Clear()
         {
+            foreach(Arrow arrow in arrows){
+                arrow.arrow.SetActive(false);
+                UnityEngine.Object.Destroy(arrow.arrow);
+            }
+            arrows = new List<Arrow>();
             players = new List<Immoralist>();
         }
         public static void suicide() {


### PR DESCRIPTION
矢印の初期化処理を入れ忘れていました